### PR TITLE
Add optional cueq sparse CG tensor-product backend

### DIFF
--- a/ASE/nemp/MPNN.py
+++ b/ASE/nemp/MPNN.py
@@ -14,6 +14,7 @@ from jax import Array
 # need to be updated for ase interface
 from ase.calculators.nemp import MLP     # need to be updated for ase interface
 from ase.calculators.nemp import sph_cal     # need to be updated for ase interface
+from ase.calculators.nemp import cueq_sparse_tp
 from ase.calculators.nemp.data_config import ModelConfig
 
 
@@ -32,6 +33,23 @@ class MPNN(nn.Module):
         dtype = self.config.initbias_neigh.dtype
 
         self.sph_cal=sph_cal.SPH_CAL(max_l = self.config.rmaxl-1)
+        self.tp_backend = getattr(self.config, "tp_backend", "custom")
+        if self.tp_backend not in ("custom", "cueq"):
+            raise ValueError(f"Unsupported tp_backend={self.tp_backend!r}; use 'custom' or 'cueq'.")
+        self.sparse_cg_polynomial = None
+        if self.tp_backend == "cueq":
+            self.sparse_cg_polynomial = cueq_sparse_tp.build_sparse_cg_polynomial(
+                index_i1=self.config.index_i1,
+                index_i2=self.config.index_i2,
+                ens_cg=self.config.ens_cg,
+                index_den=self.config.index_den,
+                index_add=self.config.index_add,
+                index_squ=self.config.index_squ,
+                num_input_orbitals=self.config.rmaxl * self.config.rmaxl,
+                num_iter_orbitals=self.config.prmaxl * self.config.prmaxl,
+                num_output_orbitals=self.config.prmaxl * self.config.prmaxl,
+                num_cg=self.config.num_cg,
+            )
 
         self.scale = self.param('scale', lambda rng: jnp.array(np.array([1.0, 0.0]*self.config.nspec), dtype=dtype))
 
@@ -181,11 +199,12 @@ class MPNN(nn.Module):
         worbital = jnp.einsum("ijk, ji ->ijk", orb_coeff[:, prmaxl_i+self.config.index_l], sph)
         init_orb = segment_sum(worbital, neighlist[0], num_segments=numatom, indices_are_sorted=True)
 
-        inter_orbital = jnp.einsum("ikj, ikj, k -> kij", init_orb[:, self.config.index_i1], iter_orb[:, self.config.index_i2], self.config.ens_cg)
-
-        mp_orbital = segment_sum(inter_orbital, self.config.index_den, num_segments=self.config.index_add.shape[0], indices_are_sorted=True)
-
-        iter_orb = segment_sum(mp_orbital*l_coeff[self.config.index_squ], self.config.index_add, num_segments=prmaxl_i * prmaxl_i)
+        iter_orb = self.sparse_cg_tensor_product(
+            init_orb=init_orb,
+            iter_orb=iter_orb,
+            l_coeff=l_coeff,
+            num_output_orbitals=prmaxl_i * prmaxl_i,
+        )
         norm = ave_neigh * ave_neigh * jnp.sqrt(self.config.count_l[pindex_l])
         iter_orb = jnp.einsum("ij, jik, ikm -> ijm", jnp.reciprocal(norm), iter_orb, contract_coeff[:, 1])
 
@@ -194,3 +213,31 @@ class MPNN(nn.Module):
         center_orbital = (center_orbital + iter_orb) / jnp.sqrt(dtype_2)
 
         return center_orbital
+
+
+    def sparse_cg_tensor_product(self, init_orb, iter_orb, l_coeff, num_output_orbitals):
+        if self.tp_backend == "custom":
+            inter_orbital = jnp.einsum(
+                "ikj, ikj, k -> kij",
+                init_orb[:, self.config.index_i1],
+                iter_orb[:, self.config.index_i2],
+                self.config.ens_cg,
+            )
+            mp_orbital = segment_sum(
+                inter_orbital,
+                self.config.index_den,
+                num_segments=self.config.index_add.shape[0],
+                indices_are_sorted=True,
+            )
+            return segment_sum(
+                mp_orbital * l_coeff[self.config.index_squ],
+                self.config.index_add,
+                num_segments=num_output_orbitals,
+            )
+        return cueq_sparse_tp.sparse_cg_tensor_product_cueq(
+            self.sparse_cg_polynomial,
+            init_orb,
+            iter_orb,
+            l_coeff,
+            num_output_orbitals=num_output_orbitals,
+        )

--- a/ASE/nemp/cueq_sparse_tp.py
+++ b/ASE/nemp/cueq_sparse_tp.py
@@ -1,0 +1,88 @@
+import numpy as np
+import jax
+import jax.numpy as jnp
+
+
+def _as_numpy_int(array):
+    return np.asarray(array, dtype=np.int64)
+
+
+def _as_numpy_float(array):
+    return np.asarray(array)
+
+
+def build_sparse_cg_polynomial(
+    *,
+    index_i1,
+    index_i2,
+    ens_cg,
+    index_den,
+    index_add,
+    index_squ,
+    num_input_orbitals,
+    num_iter_orbitals,
+    num_output_orbitals,
+    num_cg,
+):
+    import cuequivariance as cue
+
+    index_i1 = _as_numpy_int(index_i1)
+    index_i2 = _as_numpy_int(index_i2)
+    index_den = _as_numpy_int(index_den)
+    index_add = _as_numpy_int(index_add)
+    index_squ = _as_numpy_int(index_squ)
+    ens_cg = _as_numpy_float(ens_cg)
+
+    descriptor = cue.SegmentedTensorProduct.from_subscripts("i,j,k,l+ijkl")
+    descriptor.add_segments(0, [(1,)] * int(num_input_orbitals))
+    descriptor.add_segments(1, [(1,)] * int(num_iter_orbitals))
+    descriptor.add_segments(2, [(1,)] * int(num_cg))
+    descriptor.add_segments(3, [(1,)] * int(num_output_orbitals))
+
+    for path_id, cg_value in enumerate(ens_cg):
+        den_id = index_den[path_id]
+        out_id = index_add[den_id]
+        coeff_id = index_squ[den_id]
+        descriptor.add_path(
+            int(index_i1[path_id]),
+            int(index_i2[path_id]),
+            int(coeff_id),
+            int(out_id),
+            c=np.asarray(cg_value).reshape(1, 1, 1, 1),
+        )
+
+    stp = descriptor.consolidate_paths()
+    return cue.SegmentedPolynomial(
+        inputs=[stp.operands[0], stp.operands[1], stp.operands[2]],
+        outputs=[stp.operands[3]],
+        operations=[(cue.Operation([0, 1, 2, 3]), stp)],
+    )
+
+
+def sparse_cg_tensor_product_cueq(
+    polynomial,
+    init_orb,
+    iter_orb,
+    l_coeff,
+    *,
+    num_output_orbitals,
+    method="naive",
+):
+    import cuequivariance_jax as cuex
+
+    dtype = init_orb.dtype
+    num_nodes, _, num_waves = init_orb.shape
+    batch_size = num_nodes * num_waves
+
+    init_flat = init_orb.transpose(0, 2, 1).reshape(batch_size, init_orb.shape[1])
+    iter_flat = iter_orb.transpose(0, 2, 1).reshape(batch_size, iter_orb.shape[1])
+    coeff_flat = l_coeff.transpose(1, 2, 0).reshape(batch_size, l_coeff.shape[0])
+
+    [out_flat] = cuex.segmented_polynomial(
+        polynomial,
+        [init_flat, iter_flat, coeff_flat],
+        [jax.ShapeDtypeStruct((batch_size, int(num_output_orbitals)), dtype)],
+        method=method,
+        math_dtype=jnp.dtype(dtype).name,
+    )
+    return out_flat.reshape(num_nodes, num_waves, int(num_output_orbitals)).transpose(2, 0, 1)

--- a/ASE/nemp/data_config.py
+++ b/ASE/nemp/data_config.py
@@ -35,4 +35,5 @@ class ModelConfig:
     prmaxl: int = 2
     MP_loop: int = 2
     pn: int = 6
+    tp_backend: str = "custom"
 

--- a/ASE/nemp/read_json.py
+++ b/ASE/nemp/read_json.py
@@ -55,6 +55,7 @@ class JsonConfig:
     nradial: int = field(default=64)
     maxneigh_per_node: int = field(default=26)
     MP_loop: int = field(default=3)
+    tp_backend: str = field(default="custom")
     
     emb_nl: List[Any] = field(default_factory = lambda: [1, 64, 2, True])
     radial_nl: List[Any] = field(default_factory = lambda: [1, 64, 2, True])

--- a/inference_model/MPNN.py
+++ b/inference_model/MPNN.py
@@ -13,6 +13,7 @@ from jax.lax import fori_loop
 from jax import Array
 #  need to be updated for JAX_MD
 from low_level import sph_cal
+from low_level import cueq_sparse_tp
 from src.data_config import ModelConfig
 from low_level import MLP  # Refers to the final, robust MLP.py
 
@@ -32,6 +33,23 @@ class MPNN(nn.Module):
         dtype = self.config.initbias_neigh.dtype
 
         self.sph_cal=sph_cal.SPH_CAL(max_l = self.config.rmaxl-1)
+        self.tp_backend = getattr(self.config, "tp_backend", "custom")
+        if self.tp_backend not in ("custom", "cueq"):
+            raise ValueError(f"Unsupported tp_backend={self.tp_backend!r}; use 'custom' or 'cueq'.")
+        self.sparse_cg_polynomial = None
+        if self.tp_backend == "cueq":
+            self.sparse_cg_polynomial = cueq_sparse_tp.build_sparse_cg_polynomial(
+                index_i1=self.config.index_i1,
+                index_i2=self.config.index_i2,
+                ens_cg=self.config.ens_cg,
+                index_den=self.config.index_den,
+                index_add=self.config.index_add,
+                index_squ=self.config.index_squ,
+                num_input_orbitals=self.config.rmaxl * self.config.rmaxl,
+                num_iter_orbitals=self.config.prmaxl * self.config.prmaxl,
+                num_output_orbitals=self.config.prmaxl * self.config.prmaxl,
+                num_cg=self.config.num_cg,
+            )
 
         self.scale = self.param('scale', lambda rng: jnp.array(np.array([1.0, 0.0]*self.config.nspec), dtype=dtype))
 
@@ -181,11 +199,12 @@ class MPNN(nn.Module):
         worbital = jnp.einsum("ijk, ji ->ijk", orb_coeff[:, prmaxl_i+self.config.index_l], sph)
         init_orb = segment_sum(worbital, neighlist[0], num_segments=numatom, indices_are_sorted=True)
 
-        inter_orbital = jnp.einsum("ikj, ikj, k -> kij", init_orb[:, self.config.index_i1], iter_orb[:, self.config.index_i2], self.config.ens_cg)
-
-        mp_orbital = segment_sum(inter_orbital, self.config.index_den, num_segments=self.config.index_add.shape[0], indices_are_sorted=True)
-
-        iter_orb = segment_sum(mp_orbital*l_coeff[self.config.index_squ], self.config.index_add, num_segments=prmaxl_i * prmaxl_i)
+        iter_orb = self.sparse_cg_tensor_product(
+            init_orb=init_orb,
+            iter_orb=iter_orb,
+            l_coeff=l_coeff,
+            num_output_orbitals=prmaxl_i * prmaxl_i,
+        )
         norm = ave_neigh * ave_neigh * jnp.sqrt(self.config.count_l[pindex_l])
         iter_orb = jnp.einsum("ij, jik, ikm -> ijm", jnp.reciprocal(norm), iter_orb, contract_coeff[:, 1])
 
@@ -194,3 +213,31 @@ class MPNN(nn.Module):
         center_orbital = (center_orbital + iter_orb) / jnp.sqrt(dtype_2)
 
         return center_orbital
+
+
+    def sparse_cg_tensor_product(self, init_orb, iter_orb, l_coeff, num_output_orbitals):
+        if self.tp_backend == "custom":
+            inter_orbital = jnp.einsum(
+                "ikj, ikj, k -> kij",
+                init_orb[:, self.config.index_i1],
+                iter_orb[:, self.config.index_i2],
+                self.config.ens_cg,
+            )
+            mp_orbital = segment_sum(
+                inter_orbital,
+                self.config.index_den,
+                num_segments=self.config.index_add.shape[0],
+                indices_are_sorted=True,
+            )
+            return segment_sum(
+                mp_orbital * l_coeff[self.config.index_squ],
+                self.config.index_add,
+                num_segments=num_output_orbitals,
+            )
+        return cueq_sparse_tp.sparse_cg_tensor_product_cueq(
+            self.sparse_cg_polynomial,
+            init_orb,
+            iter_orb,
+            l_coeff,
+            num_output_orbitals=num_output_orbitals,
+        )

--- a/low_level/cueq_sparse_tp.py
+++ b/low_level/cueq_sparse_tp.py
@@ -1,0 +1,88 @@
+import numpy as np
+import jax
+import jax.numpy as jnp
+
+
+def _as_numpy_int(array):
+    return np.asarray(array, dtype=np.int64)
+
+
+def _as_numpy_float(array):
+    return np.asarray(array)
+
+
+def build_sparse_cg_polynomial(
+    *,
+    index_i1,
+    index_i2,
+    ens_cg,
+    index_den,
+    index_add,
+    index_squ,
+    num_input_orbitals,
+    num_iter_orbitals,
+    num_output_orbitals,
+    num_cg,
+):
+    import cuequivariance as cue
+
+    index_i1 = _as_numpy_int(index_i1)
+    index_i2 = _as_numpy_int(index_i2)
+    index_den = _as_numpy_int(index_den)
+    index_add = _as_numpy_int(index_add)
+    index_squ = _as_numpy_int(index_squ)
+    ens_cg = _as_numpy_float(ens_cg)
+
+    descriptor = cue.SegmentedTensorProduct.from_subscripts("i,j,k,l+ijkl")
+    descriptor.add_segments(0, [(1,)] * int(num_input_orbitals))
+    descriptor.add_segments(1, [(1,)] * int(num_iter_orbitals))
+    descriptor.add_segments(2, [(1,)] * int(num_cg))
+    descriptor.add_segments(3, [(1,)] * int(num_output_orbitals))
+
+    for path_id, cg_value in enumerate(ens_cg):
+        den_id = index_den[path_id]
+        out_id = index_add[den_id]
+        coeff_id = index_squ[den_id]
+        descriptor.add_path(
+            int(index_i1[path_id]),
+            int(index_i2[path_id]),
+            int(coeff_id),
+            int(out_id),
+            c=np.asarray(cg_value).reshape(1, 1, 1, 1),
+        )
+
+    stp = descriptor.consolidate_paths()
+    return cue.SegmentedPolynomial(
+        inputs=[stp.operands[0], stp.operands[1], stp.operands[2]],
+        outputs=[stp.operands[3]],
+        operations=[(cue.Operation([0, 1, 2, 3]), stp)],
+    )
+
+
+def sparse_cg_tensor_product_cueq(
+    polynomial,
+    init_orb,
+    iter_orb,
+    l_coeff,
+    *,
+    num_output_orbitals,
+    method="naive",
+):
+    import cuequivariance_jax as cuex
+
+    dtype = init_orb.dtype
+    num_nodes, _, num_waves = init_orb.shape
+    batch_size = num_nodes * num_waves
+
+    init_flat = init_orb.transpose(0, 2, 1).reshape(batch_size, init_orb.shape[1])
+    iter_flat = iter_orb.transpose(0, 2, 1).reshape(batch_size, iter_orb.shape[1])
+    coeff_flat = l_coeff.transpose(1, 2, 0).reshape(batch_size, l_coeff.shape[0])
+
+    [out_flat] = cuex.segmented_polynomial(
+        polynomial,
+        [init_flat, iter_flat, coeff_flat],
+        [jax.ShapeDtypeStruct((batch_size, int(num_output_orbitals)), dtype)],
+        method=method,
+        math_dtype=jnp.dtype(dtype).name,
+    )
+    return out_flat.reshape(num_nodes, num_waves, int(num_output_orbitals)).transpose(2, 0, 1)

--- a/src/data_config.py
+++ b/src/data_config.py
@@ -35,4 +35,5 @@ class ModelConfig:
     prmaxl: int = 2
     MP_loop: int = 2
     pn: int = 6
+    tp_backend: str = "custom"
 

--- a/src/read_json.py
+++ b/src/read_json.py
@@ -54,6 +54,7 @@ class JsonConfig:
     nradial: int = field(default=64)
     maxneigh_per_node: int = field(default=26)
     MP_loop: int = field(default=3)
+    tp_backend: str = field(default="custom")
     
     emb_nl: List[Any] = field(default_factory = lambda: [1, 64, 2, True])
     radial_nl: List[Any] = field(default_factory = lambda: [1, 64, 2, True])

--- a/tests/test_cueq_sparse_tp.py
+++ b/tests/test_cueq_sparse_tp.py
@@ -1,0 +1,126 @@
+import importlib.util
+
+import jax
+import jax.numpy as jnp
+import numpy as np
+import pytest
+from jax.ops import segment_sum
+
+from low_level import cg_cal
+from low_level import cueq_sparse_tp
+
+
+pytestmark = pytest.mark.skipif(
+    importlib.util.find_spec("cuequivariance") is None
+    or importlib.util.find_spec("cuequivariance_jax") is None,
+    reason="cuequivariance and cuequivariance_jax are required",
+)
+
+
+def _contract_sph(rmaxl, prmaxl):
+    index_i1 = []
+    index_i2 = []
+    cg_array = []
+    index_den = []
+    index_squ = []
+    index_add = []
+    count_l = np.zeros(prmaxl)
+    num_coeff = 0
+    num_den = 0
+
+    for lf in range(prmaxl):
+        for li1 in range(rmaxl):
+            low = abs(li1 - lf)
+            up = min(prmaxl, li1 + lf + 1)
+            for li2 in range(low, up):
+                if np.mod(li1 + li2 + lf, 2) < 0.5:
+                    cg = cg_cal.clebsch_gordan(li1, li2, lf)
+                    count_l[lf] += 1
+                    for mf in range(0, 2 * lf + 1):
+                        dim3 = lf * lf + mf
+                        index_add.append(dim3)
+                        index_squ.append(num_coeff)
+                        for mi1 in range(0, 2 * li1 + 1):
+                            for mi2 in range(0, 2 * li2 + 1):
+                                dim1 = li1 * li1 + mi1
+                                dim2 = li2 * li2 + mi2
+                                if np.abs(cg[mi1, mi2, mf]) > 1e-3:
+                                    index_i1.append(dim1)
+                                    index_i2.append(dim2)
+                                    cg_array.append(cg[mi1, mi2, mf])
+                                    index_den.append(num_den)
+                        num_den += 1
+                    num_coeff += 1
+
+    return {
+        "index_i1": jnp.asarray(index_i1),
+        "index_i2": jnp.asarray(index_i2),
+        "ens_cg": jnp.asarray(cg_array),
+        "index_add": jnp.asarray(index_add),
+        "index_den": jnp.asarray(index_den),
+        "index_squ": jnp.asarray(index_squ),
+        "count_l": jnp.asarray(count_l),
+        "num_cg": num_coeff,
+    }
+
+
+def _custom_sparse_tp(paths, init_orb, iter_orb, l_coeff, num_output_orbitals):
+    inter_orbital = jnp.einsum(
+        "ikj, ikj, k -> kij",
+        init_orb[:, paths["index_i1"]],
+        iter_orb[:, paths["index_i2"]],
+        paths["ens_cg"],
+    )
+    mp_orbital = segment_sum(
+        inter_orbital,
+        paths["index_den"],
+        num_segments=paths["index_add"].shape[0],
+        indices_are_sorted=True,
+    )
+    return segment_sum(
+        mp_orbital * l_coeff[paths["index_squ"]],
+        paths["index_add"],
+        num_segments=num_output_orbitals,
+    )
+
+
+def test_cueq_sparse_tp_matches_custom_lmax2():
+    rmaxl = 3
+    prmaxl = 3
+    num_nodes = 4
+    num_waves = 5
+    num_input_orbitals = rmaxl * rmaxl
+    num_output_orbitals = prmaxl * prmaxl
+
+    paths = _contract_sph(rmaxl, prmaxl)
+    key = jax.random.PRNGKey(0)
+    key_init, key_iter, key_coeff = jax.random.split(key, 3)
+
+    init_orb = jax.random.normal(key_init, (num_nodes, num_input_orbitals, num_waves), dtype=jnp.float32)
+    iter_orb = jax.random.normal(key_iter, (num_nodes, num_output_orbitals, num_waves), dtype=jnp.float32)
+    l_coeff = jax.random.normal(key_coeff, (paths["num_cg"], num_nodes, num_waves), dtype=jnp.float32)
+
+    custom = _custom_sparse_tp(paths, init_orb, iter_orb, l_coeff, num_output_orbitals)
+    polynomial = cueq_sparse_tp.build_sparse_cg_polynomial(
+        index_i1=paths["index_i1"],
+        index_i2=paths["index_i2"],
+        ens_cg=paths["ens_cg"],
+        index_den=paths["index_den"],
+        index_add=paths["index_add"],
+        index_squ=paths["index_squ"],
+        num_input_orbitals=num_input_orbitals,
+        num_iter_orbitals=num_output_orbitals,
+        num_output_orbitals=num_output_orbitals,
+        num_cg=paths["num_cg"],
+    )
+    cueq = cueq_sparse_tp.sparse_cg_tensor_product_cueq(
+        polynomial,
+        init_orb,
+        iter_orb,
+        l_coeff,
+        num_output_orbitals=num_output_orbitals,
+    )
+
+    assert cueq.shape == custom.shape
+    assert cueq.dtype == custom.dtype
+    np.testing.assert_allclose(np.asarray(cueq), np.asarray(custom), rtol=1e-5, atol=1e-6)

--- a/train/train.py
+++ b/train/train.py
@@ -187,7 +187,7 @@ coor, cell, neighlist, celllist, shiftimage, center_factor, species, numatoms, a
 initdata = (coor[0], cell[0], jnp.zeros_like(cell[0]), neighlist[0], celllist[0], shiftimage[0], center_factor[0], species[0])
 
 #=================================================Equi MPNN===================================================================
-config = ModelConfig(nspec=nspec, num_cg=num_cg, emb_nl=full_config.emb_nl, MP_nl=full_config.MP_nl, radial_nl=full_config.radial_nl, out_nl=full_config.out_nl, reduce_spec=reduce_spec, com_spec=com_spec, count_l=count_l, index_l=index_l, index_i1=index_i1, index_i2=index_i2, ens_cg=ens_cg, index_add=index_add, index_den=index_den, index_squ=index_squ, initbias_neigh=initbias_neigh, cutoff=full_config.cutoff, npaircode=full_config.npaircode, nradial=full_config.nradial, nwave=full_config.nwave, rmaxl=rmaxl, prmaxl=prmaxl, MP_loop=full_config.MP_loop, pn=full_config.pn, use_norm=full_config.use_norm, use_bias=full_config.use_bias, std=force_std, cst=1.67462)
+config = ModelConfig(nspec=nspec, num_cg=num_cg, emb_nl=full_config.emb_nl, MP_nl=full_config.MP_nl, radial_nl=full_config.radial_nl, out_nl=full_config.out_nl, reduce_spec=reduce_spec, com_spec=com_spec, count_l=count_l, index_l=index_l, index_i1=index_i1, index_i2=index_i2, ens_cg=ens_cg, index_add=index_add, index_den=index_den, index_squ=index_squ, initbias_neigh=initbias_neigh, cutoff=full_config.cutoff, npaircode=full_config.npaircode, nradial=full_config.nradial, nwave=full_config.nwave, rmaxl=rmaxl, prmaxl=prmaxl, MP_loop=full_config.MP_loop, pn=full_config.pn, use_norm=full_config.use_norm, use_bias=full_config.use_bias, std=force_std, cst=1.67462, tp_backend=full_config.tp_backend)
 
 model = MPNN.MPNN(config)
 

--- a/train_model/MPNN.py
+++ b/train_model/MPNN.py
@@ -13,6 +13,7 @@ from jax.lax import fori_loop
 from jax import Array
 #  need to be updated for JAX_MD
 from low_level import sph_cal
+from low_level import cueq_sparse_tp
 from src.data_config import ModelConfig
 from low_level import MLP  # Refers to the final, robust MLP.py
 
@@ -32,6 +33,23 @@ class MPNN(nn.Module):
         dtype = self.config.initbias_neigh.dtype
 
         self.sph_cal=sph_cal.SPH_CAL(max_l = self.config.rmaxl-1)
+        self.tp_backend = getattr(self.config, "tp_backend", "custom")
+        if self.tp_backend not in ("custom", "cueq"):
+            raise ValueError(f"Unsupported tp_backend={self.tp_backend!r}; use 'custom' or 'cueq'.")
+        self.sparse_cg_polynomial = None
+        if self.tp_backend == "cueq":
+            self.sparse_cg_polynomial = cueq_sparse_tp.build_sparse_cg_polynomial(
+                index_i1=self.config.index_i1,
+                index_i2=self.config.index_i2,
+                ens_cg=self.config.ens_cg,
+                index_den=self.config.index_den,
+                index_add=self.config.index_add,
+                index_squ=self.config.index_squ,
+                num_input_orbitals=self.config.rmaxl * self.config.rmaxl,
+                num_iter_orbitals=self.config.prmaxl * self.config.prmaxl,
+                num_output_orbitals=self.config.prmaxl * self.config.prmaxl,
+                num_cg=self.config.num_cg,
+            )
 
         self.scale = self.param('scale', lambda rng: jnp.array(np.array([1.0, 0.0]*self.config.nspec), dtype=dtype))
 
@@ -183,11 +201,12 @@ class MPNN(nn.Module):
         worbital = jnp.einsum("ijk, ji ->ijk", orb_coeff[:, prmaxl_i+self.config.index_l], sph)
         init_orb = segment_sum(worbital, neighlist[0], num_segments=nnode, indices_are_sorted=True)
 
-        inter_orbital = jnp.einsum("ikj, ikj, k -> kij", init_orb[:, self.config.index_i1], iter_orb[:, self.config.index_i2], self.config.ens_cg)
-
-        mp_orbital = segment_sum(inter_orbital, self.config.index_den, num_segments=self.config.index_add.shape[0], indices_are_sorted=True)
-
-        iter_orb = segment_sum(mp_orbital*l_coeff[self.config.index_squ], self.config.index_add, num_segments=prmaxl_i * prmaxl_i)
+        iter_orb = self.sparse_cg_tensor_product(
+            init_orb=init_orb,
+            iter_orb=iter_orb,
+            l_coeff=l_coeff,
+            num_output_orbitals=prmaxl_i * prmaxl_i,
+        )
         norm = ave_neigh * ave_neigh * jnp.sqrt(self.config.count_l[pindex_l])
         iter_orb = jnp.einsum("ij, jik, ikm -> ijm", jnp.reciprocal(norm), iter_orb, contract_coeff[:, 1])
 
@@ -196,3 +215,31 @@ class MPNN(nn.Module):
         center_orbital = (center_orbital + iter_orb) / jnp.sqrt(dtype_2)
 
         return center_orbital
+
+
+    def sparse_cg_tensor_product(self, init_orb, iter_orb, l_coeff, num_output_orbitals):
+        if self.tp_backend == "custom":
+            inter_orbital = jnp.einsum(
+                "ikj, ikj, k -> kij",
+                init_orb[:, self.config.index_i1],
+                iter_orb[:, self.config.index_i2],
+                self.config.ens_cg,
+            )
+            mp_orbital = segment_sum(
+                inter_orbital,
+                self.config.index_den,
+                num_segments=self.config.index_add.shape[0],
+                indices_are_sorted=True,
+            )
+            return segment_sum(
+                mp_orbital * l_coeff[self.config.index_squ],
+                self.config.index_add,
+                num_segments=num_output_orbitals,
+            )
+        return cueq_sparse_tp.sparse_cg_tensor_product_cueq(
+            self.sparse_cg_polynomial,
+            init_orb,
+            iter_orb,
+            l_coeff,
+            num_output_orbitals=num_output_orbitals,
+        )


### PR DESCRIPTION
## Summary
- Add `tp_backend = "custom" | "cueq"`, with `"custom"` preserved as the default.
- Encode the existing sparse CG arrays (`index_i1`, `index_i2`, `ens_cg`, `index_den`, `index_add`, `index_squ`) as a cuEquivariance segmented polynomial for the node-level tensor-product contraction in `sum_interaction()`.
- Keep the current sparse-index implementation in place and route only the targeted contractions through the optional backend.
- Add a minimal lmax=2 equivalence test comparing the custom sparse contraction against `cuequivariance_jax` on random inputs.

## Notes
- This keeps the NEMP node-level design: neighbor environments are first summed into the virtual node, then the tensor product runs on node/wave batches.
- `cg_cal.py` and `sph_cal.py` are not removed in this PR because the default custom backend and spherical-harmonic feature generation still depend on them.
- Flax NNX migration is intentionally left for a separate PR because it changes module state, checkpoint structure, and training/inference entrypoints.

## Tests
- `python -m pytest tests/test_cueq_sparse_tp.py -q` passes (`1 passed`; pytest cache warning only due local Windows permissions).
- `python -m py_compile low_level/cueq_sparse_tp.py train_model/MPNN.py inference_model/MPNN.py ASE/nemp/MPNN.py ASE/nemp/cueq_sparse_tp.py src/data_config.py src/read_json.py train/train.py tests/test_cueq_sparse_tp.py` passes.